### PR TITLE
Set-TlsMemberValue not working properly

### DIFF
--- a/Functions/Get-AllTlsSettingsFromRegistry/Get-AllTlsSettingsFromRegistry.ps1
+++ b/Functions/Get-AllTlsSettingsFromRegistry/Get-AllTlsSettingsFromRegistry.ps1
@@ -4,7 +4,7 @@ param(
 [Parameter(Mandatory=$true)][string]$MachineName,
 [Parameter(Mandatory=$false)][scriptblock]$CatchActionFunction
 )
-#Function Version 1.0
+#Function Version 1.1
 <# 
 Required Functions: 
     https://raw.githubusercontent.com/dpaulson45/PublicPowerShellScripts/master/Functions/Write-VerboseWriters/Write-VerboseWriter.ps1
@@ -46,7 +46,7 @@ param(
             }
          }
         "DisabledByDefault" {
-            if($KeyValue -ne $null)
+            if($KeyValue -eq $null)
             {
                 Write-VerboseWriter("Failed to get TLS {0} {1} Disabled By Default Key on Server {2}. Setting to false." -f $TlsVersion, $ServerClientType, $MachineName)
                 return $false 


### PR DESCRIPTION
There is a logical issue for `DisabledByDefault` check.
First, we check if the passed key value `$KeyValue` is not `$null`. We then return `$false` and so, assuming that there was no valid value passed to `Set-TlsMemberValue`. Resulting in a false/positive.