### PR TITLE
Fixed bug in determining tools only server

### DIFF
--- a/Functions/ExchangeInformation/Confirm-ExchangeShell/Confirm-ExchangeShell.ps1
+++ b/Functions/ExchangeInformation/Confirm-ExchangeShell/Confirm-ExchangeShell.ps1
@@ -101,7 +101,7 @@ Function Confirm-ExchangeShell {
         Minor       = ((Get-ItemProperty -Path $setupKey -Name "MsiProductMinor" -ErrorAction SilentlyContinue).MsiProductMinor)
         Build       = ((Get-ItemProperty -Path $setupKey -Name "MsiBuildMajor" -ErrorAction SilentlyContinue).MsiBuildMajor)
         Revision    = ((Get-ItemProperty -Path $setupKey -Name "MsiBuildMinor" -ErrorAction SilentlyContinue).MsiBuildMinor)
-        ToolsOnly   = $passed -and (Test-Path $setupKey) -and (!(Test-Path "$setupKey\Services"))
+        ToolsOnly   = $passed -and (Test-Path $setupKey) -and ($null -eq (Get-ItemProperty -Path $setupKey -Name "Services" -ErrorAction SilentlyContinue))
         RemoteShell = $passed -and (!(Test-Path $setupKey))
     }
 


### PR DESCRIPTION
Can't use `Test-Path` to the Services registry path. Need to use Get-ItemProperty