### PR TITLE
Updated New-LoggerObject for remote instances of it

### DIFF
--- a/Functions/Common/New-LoggerObject/New-LoggerObject.ps1
+++ b/Functions/Common/New-LoggerObject/New-LoggerObject.ps1
@@ -39,14 +39,15 @@ Function New-LoggerObject {
     #
     ########################
 
-
     ########## Parameter Binding Exceptions ##############
     if ($LogDirectory -eq ".") {
         $LogDirectory = (Get-Location).Path
     }
+
     if ([string]::IsNullOrWhiteSpace($LogName)) {
         throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LogName"
     }
+
     if (!(Test-Path $LogDirectory)) {
         throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LogDirectory"
     }
@@ -72,6 +73,7 @@ Function New-LoggerObject {
     if ($null -ne $HostFunctionCaller) {
         $loggerObject | Add-Member -MemberType ScriptMethod -Name "HostFunctionCaller" -Value $HostFunctionCaller
     }
+
     if ($null -ne $VerboseFunctionCaller) {
         $loggerObject | Add-Member -MemberType ScriptMethod -Name "VerboseFunctionCaller" -Value $VerboseFunctionCaller
     }
@@ -80,6 +82,7 @@ Function New-LoggerObject {
         param(
             [object]$LoggingString
         )
+
         if ($null -eq $LoggingString) {
             throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LoggingString"
         }
@@ -97,6 +100,7 @@ Function New-LoggerObject {
         param(
             [object]$LoggingString
         )
+
         if ($null -eq $LoggingString) {
             throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LoggingString"
         }
@@ -113,6 +117,7 @@ Function New-LoggerObject {
         param(
             [object]$LoggingString
         )
+
         if ($null -eq $LoggingString) {
             throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LoggingString"
         }
@@ -127,6 +132,7 @@ Function New-LoggerObject {
     $loggerObject | Add-Member -MemberType ScriptMethod -Name "UpdateFileLocation" -Value {
 
         if ($null -eq $this.FullPath) {
+
             if ($this.IncludeDateTimeToFileName) {
                 $this.InstanceBaseName = "{0}_{1}" -f $this.FileName, ((Get-Date).ToString('yyyyMMddHHmmss'))
                 $this.FullPath = "{0}\{1}.txt" -f $this.FileDirectory, $this.InstanceBaseName
@@ -158,6 +164,7 @@ Function New-LoggerObject {
     $loggerObject | Add-Member -MemberType ScriptMethod -Name "CheckFileSize" -Value {
 
         $item = Get-ChildItem $this.FullPath
+
         if (($item.Length / 1MB) -gt $this.MaxFileSizeInMB) {
             $this.UpdateFileLocation()
         }
@@ -167,6 +174,7 @@ Function New-LoggerObject {
 
         $filter = "{0}*" -f $this.InstanceBaseName
         $items = Get-ChildItem -Path $this.FileDirectory | Where-Object { $_.Name -like $filter }
+
         if ($items.Count -gt $this.NumberOfLogsToKeep) {
             do {
                 $items | Sort-Object LastWriteTime | Select-Object -First 1 | Remove-Item -Force

--- a/Functions/Common/New-LoggerObject/New-LoggerObject.ps1
+++ b/Functions/Common/New-LoggerObject/New-LoggerObject.ps1
@@ -49,7 +49,12 @@ Function New-LoggerObject {
     }
 
     if (!(Test-Path $LogDirectory)) {
-        throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LogDirectory"
+
+        try {
+            New-Item -Path $LogDirectory -ItemType Directory | Out-Null
+        } catch {
+            throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LogDirectory"
+        }
     }
 
     $loggerObject = New-Object PSCustomObject

--- a/Functions/Common/New-LoggerObject/New-LoggerObject.ps1
+++ b/Functions/Common/New-LoggerObject/New-LoggerObject.ps1
@@ -71,6 +71,7 @@ Function New-LoggerObject {
     $loggerObject | Add-Member -MemberType NoteProperty -Name "NumberOfLogsToKeep" -Value $NumberOfLogsToKeep
     $loggerObject | Add-Member -MemberType NoteProperty -Name "WriteVerboseData" -Value $VerboseEnabled
     $loggerObject | Add-Member -MemberType NoteProperty -Name "PreventLogCleanup" -Value $false
+    $loggerObject | Add-Member -MemberType NoteProperty -Name "LoggerDisabled" -Value $false
     $loggerObject | Add-Member -MemberType ScriptMethod -Name "ToLog" -Value ${Function:Write-ToLog}
     $loggerObject | Add-Member -MemberType ScriptMethod -Name "WriteHostWriter" -Value ${Function:Write-ScriptMethodHostWriter}
     $loggerObject | Add-Member -MemberType ScriptMethod -Name "WriteVerboseWriter" -Value ${Function:Write-ScriptMethodVerboseWriter}
@@ -87,6 +88,10 @@ Function New-LoggerObject {
         param(
             [object]$LoggingString
         )
+
+        if ($this.LoggerDisabled) {
+            return
+        }
 
         if ($null -eq $LoggingString) {
             throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LoggingString"
@@ -106,6 +111,10 @@ Function New-LoggerObject {
             [object]$LoggingString
         )
 
+        if ($this.LoggerDisabled) {
+            return
+        }
+
         if ($null -eq $LoggingString) {
             throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LoggingString"
         }
@@ -123,6 +132,10 @@ Function New-LoggerObject {
             [object]$LoggingString
         )
 
+        if ($this.LoggerDisabled) {
+            return
+        }
+
         if ($null -eq $LoggingString) {
             throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LoggingString"
         }
@@ -135,6 +148,10 @@ Function New-LoggerObject {
     }
 
     $loggerObject | Add-Member -MemberType ScriptMethod -Name "UpdateFileLocation" -Value {
+
+        if ($this.LoggerDisabled) {
+            return
+        }
 
         if ($null -eq $this.FullPath) {
 
@@ -157,6 +174,10 @@ Function New-LoggerObject {
 
     $loggerObject | Add-Member -MemberType ScriptMethod -Name "LogUpKeep" -Value {
 
+        if ($this.LoggerDisabled) {
+            return
+        }
+
         if ($this.NextFileCheckTime -gt [System.DateTime]::Now) {
             return
         }
@@ -168,6 +189,10 @@ Function New-LoggerObject {
 
     $loggerObject | Add-Member -MemberType ScriptMethod -Name "CheckFileSize" -Value {
 
+        if ($this.LoggerDisabled) {
+            return
+        }
+
         $item = Get-ChildItem $this.FullPath
 
         if (($item.Length / 1MB) -gt $this.MaxFileSizeInMB) {
@@ -176,6 +201,10 @@ Function New-LoggerObject {
     }
 
     $loggerObject | Add-Member -MemberType ScriptMethod -Name "CheckNumberOfFiles" -Value {
+
+        if ($this.LoggerDisabled) {
+            return
+        }
 
         $filter = "{0}*" -f $this.InstanceBaseName
         $items = Get-ChildItem -Path $this.FileDirectory | Where-Object { $_.Name -like $filter }
@@ -190,10 +219,22 @@ Function New-LoggerObject {
 
     $loggerObject | Add-Member -MemberType ScriptMethod -Name "RemoveLatestLogFile" -Value {
 
+        if ($this.LoggerDisabled) {
+            return
+        }
+
         if (!$this.PreventLogCleanup) {
             $item = Get-ChildItem $this.FullPath
             Remove-Item $item -Force
         }
+    }
+
+    $loggerObject | Add-Member -MemberType ScriptMethod -Name "DisableLogger" -Value {
+        $this.LoggerDisabled = $true
+    }
+
+    $loggerObject | Add-Member -MemberType ScriptMethod -Name "EnableLogger" -Value {
+        $this.LoggerDisabled = $false
     }
 
     $loggerObject.UpdateFileLocation()

--- a/Functions/Common/New-LoggerObject/README.md
+++ b/Functions/Common/New-LoggerObject/README.md
@@ -5,9 +5,9 @@ Function that is used to create an object for you to be able to write data withi
 
 Parameter | Description 
 ----------|------------
-LogDirectory | Provide a valid directory where we are going to be writting out the log file. Default is current running path. 
+LogDirectory | Provide a valid directory where we are going to be writing out the log file. Default is current running path. 
 LogName | Provide a custom name for the log file. Default "Script_Logging". 
-EnableDateTime | Adds the current date and time to the line that you are writting out to the screen and log file. Default True.
+EnableDateTime | Adds the current date and time to the line that you are writing out to the screen and log file. Default True.
 IncludeDateTimeToFileName | Appends the date and time in the following format yyyyMMddHHmmss to the log file name. Default True.
 MaxFileSizeInMB | The max size a file will get to before rolling over to the next log file. Default 10 MB. 
 CheckSizeIntervalMinutes | The interval that we check the size of the log file. Default 10 Minutes. 
@@ -28,7 +28,9 @@ UpdateFileLocation() | Updates the file location if a new file is needed to be c
 WriteHost(string WriteString) | Used to call the WriteHostWriter() and ToLog() for what you wish to log. 
 WriteVerbose(string WriteString) | used to call WriteVerboseWriter() and ToLog() for what you wish to log. Only information will be displayed if VerboseEnabled is set to true. 
 WriteHostWriter(string WriteString) | Used to call Write-Host. 
-WriteVerboseWriter(string WriteString) | Used to call Write-Host. Will only dispaly information if VerboseEnabled is set to true. 
+WriteVerboseWriter(string WriteString) | Used to call Write-Host. Will only display information if VerboseEnabled is set to true.
+DisableLogger() | Disable the logger from being able to do anything.
+EnableLogger() | Enable the logger to work as normal.
 
 # How To Use 
 


### PR DESCRIPTION
Once we execute on a remote machine, we might want to start logging right away. So we try to create the directory in the script itself.

You also might want to disable the logger if you are zipping up the directory that contains all your information.