### PR TITLE
Run local improvements

### DIFF
--- a/Functions/Common/Invoke-ScriptBlockHandler/Invoke-ScriptBlockHandler.ps1
+++ b/Functions/Common/Invoke-ScriptBlockHandler/Invoke-ScriptBlockHandler.ps1
@@ -18,7 +18,7 @@ Function Invoke-ScriptBlockHandler {
         Write-VerboseWriter($ScriptBlockDescription)
     }
     try {
-        if ($ComputerName -ne $env:COMPUTERNAME) {
+        if (($ComputerName).Split(".")[0] -ne $env:COMPUTERNAME) {
             $params = @{
                 ComputerName = $ComputerName
                 ScriptBlock  = $ScriptBlock

--- a/Functions/ComputerInformation/Get-AllNicInformation/Get-AllNicInformation.ps1
+++ b/Functions/ComputerInformation/Get-AllNicInformation/Get-AllNicInformation.ps1
@@ -64,9 +64,16 @@ Function Get-AllNicInformation {
         )
         try {
             $currentErrors = $Error.Count
-            $cimSession = New-CimSession -ComputerName $ComputerName -ErrorAction Stop
-            $networkIpConfiguration = Get-NetIPConfiguration -CimSession $CimSession -ErrorAction Stop | Where-Object { $_.NetAdapter.MediaConnectionState -eq "Connected" }
-
+            $params = @{
+                ErrorAction = "Stop"
+            }
+            if(($ComputerName).Split(".")[0] -ne $env:COMPUTERNAME)
+            {
+                $cimSession = New-CimSession -ComputerName $ComputerName -ErrorAction Stop
+                $params.Add("CimSession", $CimSession)
+            }
+            $networkIpConfiguration = Get-NetIPConfiguration @params | Where-Object { $_.NetAdapter.MediaConnectionState -eq "Connected" }
+            
             if ($null -ne $CatchActionFunction) {
                 $index = 0
                 while ($index -lt ($Error.Count - $currentErrors)) {


### PR DESCRIPTION
Improvement for `Get-AllNicInformation` and `Invoke-ScriptBlockHandler`. If the script is executed against the local machine using `-server` parameter and passing `Fqdn`, the logic to detect if the execution is against the local machine doesn't work well. 
We now split the value which was passed (if possible) and checking the first part of it against `$env:Computername`.